### PR TITLE
Fix Testnet deployment address

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alilloig
+* @onflow/flow-smart-contracts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,24 @@
 name: Run CLI Commands on PR
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    types: [opened, synchronize]
+    branches:
+      - main
 
 jobs:
-  run-commands:
+  tests:
+    name: Flow CLI Tests
     runs-on: ubuntu-latest
-    
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: "1.22"
-      - uses: actions/cache@v1
+          go-version: "1.23.x"
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -24,8 +29,10 @@ jobs:
       - name: Install Flow CLI
         run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
       - name: Flow CLI Version
-        run: flow-c1 version
+        run: flow version
       - name: Update PATH
         run: echo "/root/.local/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: flow deps install --skip-alias --skip-deployments
       - name: Run tests
-        run: flow-c1 test test/band_oracle_tests.cdc
+        run: flow test --cover --covercode="contracts" --coverprofile="coverage.lcov" ./test/*_tests.cdc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# flow
+*.pkey
+*.pem
+coverage.lcov
+coverage.json

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To learn more about Band Protocol please refer to: https://faq.bandprotocol.com/
 |Name|Testnet|Mainnet|
 |----|-------|-------|
 |[BandOracle](contracts/BandOracle.cdc)|[0x2c71de7af78d1adf](https://contractbrowser.com/A.2c71de7af78d1adf.BandOracle)|[]()|
-|[BandOracle](contracts/BandOracle.cdc)|[]()|[0x6801a6222ebf784a](https://contractbrowser.com/A.6801a6222ebf784a.BandOracle)|
+|[BandOracle](contracts/BandOracle.cdc)|[]()|[0x9fb6606c300b5051](https://contractbrowser.com/A.9fb6606c300b5051.BandOracle)|
 
 ## How it works?
 The contract keeps a record of symbols and the corresponding financial price data for them. While financial data are only updated by authorized BandChain relayers, they can be queried via a script by any user or application on the Flow blockchain.

--- a/flow.json
+++ b/flow.json
@@ -5,7 +5,7 @@
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"testing": "0000000000000006",
-				"testnet": "4772ee0aba864de9"
+				"testnet": "9fb6606c300b5051"
 			}
 		}
 	},
@@ -99,7 +99,7 @@
 			"key": "2b42bf501bb3e07e9332b0cda9e68c18d0591cdc54aa701fb111991adf1a99fe"
 		},
 		"testnet-oracle": {
-			"address": "4772ee0aba864de9",
+			"address": "9fb6606c300b5051",
 			"key": {
 				"type": "file",
 				"location": "testnet-oracle.pkey"


### PR DESCRIPTION
Related: https://github.com/onflow/docs/pull/1487

### Description

Update BandOracle Testnet deployment address from a deprecated deployment to the currently supported address.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 